### PR TITLE
spec: adjust when the stack limits are evaluated

### DIFF
--- a/spec/runtime.mkd
+++ b/spec/runtime.mkd
@@ -106,10 +106,3 @@ The external invocation of an exported function is augmented with the following 
 **Note**: Instrumentation may implement this via the export indirection mechanism specified in an
 appendix, however implementations are required to _not_ utilize stack indirection if they implement
 this behaviour in some other manner, as this may lead to double-charging.
-
-## Other
-
-NOTE: Execution of an intermediate reduction of some aggregate instruction may require more stack
-space than occuppied strictly by the input operands to the instruction. The runtime is responsible
-for reserving sufficient space required by these aggregate instructions as they are not modelled by
-the stack limits imposed by this specification.

--- a/spec/stack_size.mkd
+++ b/spec/stack_size.mkd
@@ -1,0 +1,20 @@
+# Appendix I: Computing the maximum stack size for a function
+
+The maximum stack size for a function is determined by modelling the stack operations of each
+operation as described in the section 4.4.
+
+When considering the instructions which enter a block (`block`, `if`, `else`, etc.), the stack
+capacity required to evaluate the enclosed instruction sequence should be considered part of the
+enclosing block’s stack size requirements (except for function invocation).
+
+Instructions made unreachable by an unconditional control flow operation (i.e. `unreachable`, `br`,
+`br_table`, `return`) shall not contribute to the maximum stack size computation. Conditional
+branching must pick the greatest size possible between all branches.
+
+## The reduction rule exception
+
+Execution of an intermediate reduction of the aggregate instructions (an example of an aggregate
+instruction is `table.fill`, which in turn may execute `table.fill` again) may require more stack
+space than occuppied by strictly the input/output operands to the instruction. The implementations
+are responsible for reserving sufficient red-zone stack space required by these aggregate
+instructions as they are not modelled by the maximum stack size computation.


### PR DESCRIPTION
This changes the specification to require that the stack limits are enforced at the function call, rather than on every stack operation.

Doing the latter requires that, in case a `trap` does occur, any side effects are executed before the `trap`. However, in practice many VM implementations will want to allocate the stack space upon the function entry and the way the reserved stack space is used is often unpredictable.

As thus there isn’t a guarantee that the more-granularly enforced stack validation will actually interact correctly with the realities of the implementation concerns.

Unfortunately this also invalidates the implementation in the reference interpreter. The current reference will output the stack size trace throughout the execution, however given a snippet along the lines of

```wast
if
    (i32.const 42)
    drop
else
    (v128.const 42)
    drop
end
```

the interpreter would determine the maximum stack usage to be 4 bytes worth of values if the `if` branch was taken. The typical VM implementation, in absence of any other optimizations, would be required to reserve at least 16 bytes instead to also account for the `else` branch.

cc #14