### PR TITLE
interpreter: add a just_run action

### DIFF
--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -14,6 +14,7 @@ and definition' =
 type action = action' Source.phrase
 and action' =
   | Invoke of var option * Ast.name * literal list
+  | Run of var option * Ast.name * literal list
   | Get of var option * Ast.name
 
 type nanop = nanop' Source.phrase

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -703,6 +703,8 @@ let action mode act =
   match act.it with
   | Invoke (x_opt, name, lits) ->
     Node ("invoke" ^ access x_opt name, List.map (literal mode) lits)
+  | Run (x_opt, name, lits) ->
+    Node ("just_run" ^ access x_opt name, List.map (literal mode) lits)
   | Get (x_opt, name) ->
     Node ("get" ^ access x_opt name, [])
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -82,7 +82,7 @@ let character =
     [^'"''\\''\x00'-'\x1f''\x7f'-'\xff']
   | utf8enc
   | '\\'escape
-  | '\\'hexdigit hexdigit 
+  | '\\'hexdigit hexdigit
   | "\\u{" hexnum '}'
 
 let nat = num | "0x" hexnum
@@ -677,6 +677,7 @@ rule token = parse
       | "script" -> SCRIPT
       | "register" -> REGISTER
       | "invoke" -> INVOKE
+      | "just_run" -> JUSTRUN
       | "get" -> GET
       | "assert_malformed" -> ASSERT_MALFORMED
       | "assert_invalid" -> ASSERT_INVALID

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -224,7 +224,7 @@ let inline_type_explicit (c : context) x ft at =
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY DATA DECLARE OFFSET ITEM IMPORT EXPORT
 %token MODULE BIN QUOTE
-%token SCRIPT REGISTER INVOKE GET
+%token SCRIPT REGISTER INVOKE GET JUSTRUN
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
 %token NAN
@@ -1047,6 +1047,8 @@ script_module :
 action :
   | LPAR INVOKE module_var_opt name literal_list RPAR
     { Invoke ($3, $4, $5) @@ at () }
+  | LPAR JUSTRUN module_var_opt name literal_list RPAR
+    { Run ($3, $4, $5) @@ at () }
   | LPAR GET module_var_opt name RPAR
     { Get ($3, $4) @@ at() }
 


### PR DESCRIPTION
This is pretty much the same as `invoke` but ignores any traps that come up as a result of executing the action.