### PR TITLE
interpreter: don't print gas insns all the time

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -195,7 +195,7 @@ let apply_fees (c: config) : config =
   if (Int64.compare e_cost !gas) > 0 then
     Exhaustion.error e.at "gas pool is empty"
   else if (Int64.compare e_cost 0L) != 0 then
-    if c.trace_gas then Printf.printf "gas: %Ld %s" e_cost (string_of_admin_instr e);
+    if c.trace_gas then Printf.printf "gas: %Ld %s" e_cost (if !Flags.trace_gas_ops then string_of_admin_instr e else "\n");
     gas := Int64.sub !gas e_cost;
     c
 

--- a/interpreter/main/flags.ml
+++ b/interpreter/main/flags.ml
@@ -8,3 +8,4 @@ let harness = ref true
 let budget = ref 256
 let gas = ref 0xFFFFFFFFFFFFFFFL
 let trace_gas = ref false
+let trace_gas_ops = ref false

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -36,6 +36,7 @@ let argspec = Arg.align
   "-d", Arg.Set Flags.dry, " dry, do not run program";
   "-t", Arg.Set Flags.trace, " trace execution";
   "-tg", Arg.Set Flags.trace_gas, " trace gas charges";
+  "-tgo", Arg.Set Flags.trace_gas_ops, " log operations that incurred gas changes (good for debugging)";
   "-v", Arg.Unit banner, " show version"
 ]
 


### PR DESCRIPTION
This is pretty expensive, especially with deeply nested structures, which can lead to exponential test execution time for no good reason. I used these for debugging purposes in the past, so i left the old behaviour accessible via a flag.