### PR TITLE
switch to a released version of cargo-bolero

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,9 +29,10 @@ jobs:
           version: ">= 416.0.0"
       - run: rustup default nightly
       - run: opam install ocamlbuild
-      # See Cargo.toml for reasons
-      - run: cargo install --git https://github.com/Ekleog-NEAR/bolero --rev 362328af9f0539f9d6ee62bb4334afaa0a71b572
-      - run: opam exec -- cargo +nightly bolero build-clusterfuzz --all-features
+      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+        with:
+          crate: cargo-bolero
       - run: |
           NAME="finite-wasm-$(env TZ=Etc/UTC date +"%Y%m%d%H%M%S")"
+          opam exec -- cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/finite-wasm/$NAME.tar.gz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,7 @@ wast = { version = "52", optional = true }
 
 [dev-dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
-# Need a fork of bolero for camshaft/bolero#161, #162 and #163. Also update fuzz.yml when they land.
-bolero = { git = "https://github.com/Ekleog-NEAR/bolero", rev = "362328af9f0539f9d6ee62bb4334afaa0a71b572", version = "0.9.0", features = ["arbitrary"] }
+bolero = { version = "0.10.0", features = ["arbitrary"] }
 criterion = "0.5.0"
 rayon = "1.6.1"
 tempfile = "3.7"


### PR DESCRIPTION
Also moving the bolero build after the name-setting, so that two commits getting CI’d around the same time don’t risk alphabetical order inversion.