### PR TITLE
support component model in stack analysis

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: ocaml/setup-ocaml@36465e9a68c360c87f287ad8e2305ca507e54be8
         with:
           ocaml-compiler: 4.13.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "component-model"]
+	path = component-model
+	url = https://github.com/WebAssembly/component-model.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ walkdir = "2.3.0"
 wasm-instrument = "0.4"
 wasm-smith = "0.228"
 wasmparser = "0.228.0"
+wat = "1.239"
 
 [features]
 instrument = ["wasm-encoder"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ prefix-sum-vec = "0.1.2"
 tempfile = { version = "3.5", optional = true }
 wasm-encoder = { version = "0.228.0", optional = true, features = ["wasmparser"] }
 wasmprinter = { version = "0.228", optional = true }
-wast = { version = "228", optional = true }
+wast = { version = "239", optional = true }
 
 [dev-dependencies]
 arbitrary = { version = "1.3", features = ["derive"] }
@@ -53,6 +53,7 @@ wasm-instrument = "0.4"
 wasm-smith = "0.228"
 wasmparser = "0.228.0"
 wat = "1.239"
+wast = "239"
 
 [features]
 instrument = ["wasm-encoder"]

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,10 @@ targets = [
 multiple-versions = "deny"
 wildcards = "deny"
 
+skip = [
+    { name = "hashbrown", version = "0.15.5" },
+]
+
 [licenses]
 allow = [
     "Apache-2.0",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,499 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1757947352,
+        "narHash": "sha256-JaA9sA+xU6k36LnLKMxvLb/FEKwiDkGRtkoZNXDsrrQ=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "3fbd1d0e5054bf36f8789a023d446ba44d98b044",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1757183466,
+        "narHash": "sha256-kTdCCMuRE+/HNHES5JYsbRHmgtr+l9mOtf5dpcMppVc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d599ae4847e7f87603e7082d73ca673aa93c916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679255352,
+        "narHash": "sha256-nkGwGuNkhNrnN33S4HIDV5NzkzMLU5mNStRn9sZwq8c=",
+        "owner": "rvolosatovs",
+        "repo": "crane",
+        "rev": "cec65880599a4ec6426186e24342e663464f5933",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "ref": "feat/wit",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs-nixos"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1758091097,
+        "narHash": "sha256-p2FIwAaUCoKY9mZSPAMQYQ7CwwhfvGC4VIfLapAdfOE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b60fe116b9495df516f57837bb04a4f89f3aa7ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1679552560,
+        "narHash": "sha256-L9Se/F1iLQBZFGrnQJO8c9wE5z0Mf8OiycPGP9Y96hA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "fb49a9f5605ec512da947a21cc7e4551a3950397",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "macos-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1694769349,
+        "narHash": "sha256-TEvVJy+NMPyzgWSk/6S29ZMQR+ICFxSdS3tw247uhFc=",
+        "type": "tarball",
+        "url": "https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.0/MacOSX14.0.sdk.tar.xz"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-filter_2": {
+      "locked": {
+        "lastModified": 1678109515,
+        "narHash": "sha256-C2X+qC80K2C1TOYZT8nabgo05Dw2HST/pSn6s+n6BO8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "aa9ff6ce4a7f19af6415fb3721eaa513ea6c763c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-flake-tests": {
+      "locked": {
+        "lastModified": 1677844186,
+        "narHash": "sha256-ErJZ/Gs1rxh561CJeWP5bohA2IcTq1rDneu1WT6CVII=",
+        "owner": "antifuchs",
+        "repo": "nix-flake-tests",
+        "rev": "bbd9216bd0f6495bb961a8eb8392b7ef55c67afb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "antifuchs",
+        "repo": "nix-flake-tests",
+        "type": "github"
+      }
+    },
+    "nix-log": {
+      "inputs": {
+        "nix-flake-tests": "nix-flake-tests",
+        "nixify": "nixify_2",
+        "nixlib": "nixlib_2"
+      },
+      "locked": {
+        "lastModified": 1755067742,
+        "narHash": "sha256-eMGTFvsZUhfMMnlpvvW+lerCLoAFkntXg9X/3u1uUlI=",
+        "owner": "rvolosatovs",
+        "repo": "nix-log",
+        "rev": "e85e73aeb90897c8e1bc44a6613d1ccba411a769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nix-log",
+        "type": "github"
+      }
+    },
+    "nixify": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "macos-sdk": "macos-sdk",
+        "nix-filter": "nix-filter",
+        "nix-log": "nix-log",
+        "nixlib": [
+          "nixlib"
+        ],
+        "nixpkgs-darwin": "nixpkgs-darwin",
+        "nixpkgs-nixos": "nixpkgs-nixos",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1758201146,
+        "narHash": "sha256-OM34ULCIZcmXY01XsqTrgi/aobdNi8+JjcuXyxcXdgM=",
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "rev": "d39038a87983d275969898ad1f60b987f7127f89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "type": "github"
+      }
+    },
+    "nixify_2": {
+      "inputs": {
+        "crane": "crane_2",
+        "fenix": "fenix_2",
+        "flake-utils": "flake-utils_2",
+        "nix-filter": "nix-filter_2",
+        "nixlib": "nixlib",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1679748566,
+        "narHash": "sha256-yA4yIJjNCOLoUh0py9S3SywwbPnd/6NPYbXad+JeOl0=",
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "rev": "80e823959511a42dfec4409fef406a14ae8240f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1679187309,
+        "narHash": "sha256-H8udmkg5wppL11d/05MMzOMryiYvc403axjDNZy1/TQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "44214417fe4595438b31bdb9469be92536a61455",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_2": {
+      "locked": {
+        "lastModified": 1679791877,
+        "narHash": "sha256-tTV1Mf0hPWIMtqyU16Kd2JUBDWvfHlDC9pF57vcbgpQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "cc060ddbf652a532b54057081d5abd6144d01971",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_3": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679577639,
+        "narHash": "sha256-7u7bsNP0ApBnLgsHVROQ5ytoMqustmMVMgtaFS/P7EU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8f1bcd72727c5d4cd775545595d068be410f2a7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1757951549,
+        "narHash": "sha256-Nwt3kxb8tkh+lqz1uKIyYkMAIV8k/5ECdRUzOujtTr0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "04389cd713308d659e275e5ad72732896a2f8d58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-nixos": {
+      "locked": {
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixify": "nixify",
+        "nixlib": "nixlib_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1757362324,
+        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679520343,
+        "narHash": "sha256-AJGSGWRfoKWD5IVTu1wEsR990wHbX0kIaolPqNMEh0c=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "eb791f31e688ae00908eb75d4c704ef60c430a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nix-log",
+          "nixify",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679537973,
+        "narHash": "sha256-R6borgcKeyMIjjPeeYsfo+mT8UdS+OwwbhhStdCfEjg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fbc7ae3f14d32e78c0e8d7865f865cc28a46b232",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs-nixos"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758076341,
+        "narHash": "sha256-ZKi6pyRDw2/3xU7qxd+2+lneQXUOe92TiF+10DflolM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "562fb6f14678eb9b8a36829140f6a4d0737776d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  nixConfig.extra-substituters = [
+    "https://nixify.cachix.org"
+    "https://nix-community.cachix.org"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+  ];
+
+  inputs.nixify.inputs.nixlib.follows = "nixlib";
+  inputs.nixify.url = "github:rvolosatovs/nixify";
+  inputs.nixlib.url = "github:nix-community/nixpkgs.lib";
+
+  outputs = {
+    nixify,
+    nixlib,
+    ...
+  }:
+    with nixlib.lib;
+    with nixify.lib;
+      rust.mkFlake {
+        src = ./.;
+
+        withDevShells = {
+          devShells,
+          pkgs,
+          ...
+        }:
+          extendDerivations {
+            buildInputs = let
+              ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
+            in [
+              ocamlPackages.ocaml
+              ocamlPackages.ocamlbuild
+            ];
+          }
+          devShells;
+      };
+}

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -43,7 +43,7 @@ mod error;
 mod optimize;
 
 /// The type of a particular instrumentation point (as denoted by its offset.)
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum InstrumentationKind {
     /// This instrumentation point precedes an instruction that is largely uninteresting for the
     /// purposes of gas analysis, besides its inherent cost.

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -465,9 +465,10 @@ impl<'a> InstrumentContext<'a> {
             // scale of the work.) This also makes these intrinsics compatible with non-multi-value
             // VMs still.
             let copy_init_fill_fnty = self.type_section.len();
-            self.type_section
-                .ty()
-                .function([we::ValType::I32, we::ValType::I64, we::ValType::I64], [we::ValType::I32]);
+            self.type_section.ty().function(
+                [we::ValType::I32, we::ValType::I64, we::ValType::I64],
+                [we::ValType::I32],
+            );
             // By inserting the imports at the beginning of the import section we make the new
             // function index mapping trivial (it is always just an increment by F)
             debug_assert_eq!(self.import_section.len(), GAS_INSTRUMENTATION_FN);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl<'b, SC: max_stack::Config<'b>, GC: gas::Config<'b>> Analysis<SC, GC> {
 /// depends on how the instrumentation is implemented. The instrumentation provided by the
 /// `instrument` module, for example, introduces separate imports of gas instrumentation functions
 /// for each aggregate instruction supported by this module.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Fee {
     /// Constant fee factor.
     pub constant: u64,
@@ -252,7 +252,10 @@ impl Fee {
     };
 
     pub fn constant(constant: u64) -> Self {
-        Self { constant, linear: 0 }
+        Self {
+            constant,
+            linear: 0,
+        }
     }
 
     pub(crate) fn checked_add(self, other: Fee) -> Option<Self> {
@@ -267,7 +270,7 @@ impl Fee {
 ///
 /// This analysis collects information necessary to implement all of the transformations in one go,
 /// so that re-parsing the module multiple times is not necessary.
-#[derive(Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct AnalysisOutcome {
     /// The sizes of the stack frame for each function in the module, *excluding* imports.
     ///

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -1,0 +1,140 @@
+use finite_wasm::gas::InstrumentationKind;
+use finite_wasm::{max_stack, prefix_sum_vec, wasmparser, AnalysisOutcome, Error, Fee};
+
+fn analyze(wasm: &[u8]) -> Result<AnalysisOutcome, Error> {
+    struct DefaultStackConfig;
+
+    impl max_stack::SizeConfig for DefaultStackConfig {
+        fn size_of_value(&self, _ty: wasmparser::ValType) -> u8 {
+            u8::MAX
+        }
+
+        fn size_of_function_activation(
+            &self,
+            _locals: &prefix_sum_vec::PrefixSumVec<wasmparser::ValType, u32>,
+        ) -> u64 {
+            u64::MAX / 128
+        }
+    }
+
+    struct DefaultGasConfig;
+
+    macro_rules! gas_visit {
+    (visit_end => $({ $($arg:ident: $argty:ty),* })?) => {};
+    (visit_else => $({ $($arg:ident: $argty:ty),* })?) => {};
+    ($visit:ident => $({ $($arg:ident: $argty:ty),* })?) => {
+        fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
+            Fee::constant(u64::MAX / 128) // allow for 128 operations before an overflow would occur.
+        }
+    };
+
+    ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident ($($ann:tt)*))*) => {
+        $(gas_visit!{ $visit => $({ $($arg: $argty),* })? })*
+    }
+}
+
+    impl<'a> wasmparser::VisitOperator<'a> for DefaultGasConfig {
+        type Output = Fee;
+        fn visit_end(&mut self) -> Fee {
+            Fee::ZERO
+        }
+        fn visit_else(&mut self) -> Fee {
+            Fee::ZERO
+        }
+        wasmparser::for_each_visit_operator!(gas_visit);
+    }
+
+    impl<'a> wasmparser::VisitSimdOperator<'a> for DefaultGasConfig {
+        wasmparser::for_each_visit_simd_operator!(gas_visit);
+    }
+
+    let wasm = wat::parse_bytes(wasm).expect("failed to parse WAT");
+    finite_wasm::Analysis::new()
+        .with_stack(DefaultStackConfig)
+        .with_gas(DefaultGasConfig)
+        .analyze(&wasm)
+}
+
+#[test]
+fn analyze_component() {
+    const FUNC: &str = r#"(func (export "main")
+    (i32.div_u
+      (i32.const 0)
+      (f32.gt
+        (f32.copysign
+          (f32.const 1.0)
+          (f32.sqrt (f32.const -1.0)))
+        (f32.const 0)))
+    drop
+  )"#;
+
+    assert_eq!(
+        analyze(
+            format!(
+                r#"
+(module
+   {FUNC}
+)"#
+            )
+            .as_bytes()
+        )
+        .unwrap(),
+        AnalysisOutcome {
+            function_frame_sizes: vec![144115188075855871],
+            function_operand_stack_sizes: vec![765],
+            gas_offsets: vec![[33, 54].into()],
+            gas_costs: vec![[
+                Fee {
+                    constant: 1152921504606846968,
+                    linear: 0
+                },
+                Fee {
+                    constant: 144115188075855871,
+                    linear: 0
+                }
+            ]
+            .into()],
+            gas_kinds: vec![[
+                InstrumentationKind::PreControlFlow,
+                InstrumentationKind::PostControlFlow
+            ]
+            .into()]
+        }
+    );
+
+    assert_eq!(
+        analyze(
+            format!(
+                r#"
+(component
+  (core module
+    {FUNC}
+  )
+)"#
+            )
+            .as_bytes()
+        )
+        .unwrap(),
+        AnalysisOutcome {
+            function_frame_sizes: vec![144115188075855871],
+            function_operand_stack_sizes: vec![765],
+            gas_offsets: vec![[43, 64].into()],
+            gas_costs: vec![[
+                Fee {
+                    constant: 1152921504606846968,
+                    linear: 0
+                },
+                Fee {
+                    constant: 144115188075855871,
+                    linear: 0
+                }
+            ]
+            .into()],
+            gas_kinds: vec![[
+                InstrumentationKind::PreControlFlow,
+                InstrumentationKind::PostControlFlow
+            ]
+            .into()]
+        }
+    );
+}

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -1,5 +1,7 @@
 use finite_wasm::gas::InstrumentationKind;
 use finite_wasm::{max_stack, prefix_sum_vec, wasmparser, AnalysisOutcome, Error, Fee};
+use std::fs;
+use std::path::PathBuf;
 
 fn analyze(wasm: &[u8]) -> Result<AnalysisOutcome, Error> {
     struct DefaultStackConfig;
@@ -137,4 +139,87 @@ fn analyze_component() {
             .into()]
         }
     );
+}
+
+#[test]
+fn analyze_spec() {
+    let tests = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("component-model")
+        .join("test");
+    let tests = fs::read_dir(tests).expect("failed to read component model spec test directory");
+    let tests = tests
+        .filter_map(|entry| {
+            let entry = entry.unwrap();
+            let ty = entry.file_type().unwrap();
+            if !ty.is_dir() {
+                return None;
+            }
+            let d = fs::read_dir(entry.path())
+                .expect("failed to read component model spec test subdirectory");
+            Some(d.filter_map(|entry| {
+                let entry = entry.unwrap();
+                let ty = entry.file_type().unwrap();
+                if !ty.is_file() {
+                    return None;
+                }
+                let path = entry.path();
+                let buf = fs::read(&path).expect("failed to read test");
+                Some((path, buf))
+            }))
+        })
+        .flatten();
+    for (_, buf) in tests {
+        let buf = str::from_utf8(&buf).unwrap();
+
+        let mut lexer = wast::lexer::Lexer::new(buf);
+        lexer.allow_confusing_unicode(true);
+        let buf = wast::parser::ParseBuffer::new_with_lexer(lexer).unwrap();
+        let wast: wast::Wast = wast::parser::parse(&buf).unwrap();
+        for directive in wast.directives {
+            match directive {
+                wast::WastDirective::Module(wast::QuoteWat::Wat(wast::Wat::Module(..))) => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+                wast::WastDirective::Module(wast::QuoteWat::QuoteModule(_, _)) => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+                wast::WastDirective::Module(wast::QuoteWat::Wat(wast::Wat::Component(mut c)))
+                | wast::WastDirective::ModuleDefinition(wast::QuoteWat::Wat(
+                    wast::Wat::Component(mut c),
+                )) => {
+                    let c = c.encode().unwrap();
+                    let _outcome = analyze(&c).unwrap();
+                }
+                wast::WastDirective::Module(wast::QuoteWat::QuoteComponent(_, _)) => {
+                    // Same
+                    continue;
+                }
+                wast::WastDirective::ModuleDefinition(_) => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+
+                // Ignore the “operations”, we only care about module analysis results.
+                wast::WastDirective::ModuleInstance { .. } => continue,
+                wast::WastDirective::Register { .. } => continue,
+                wast::WastDirective::Invoke(..) => continue,
+                wast::WastDirective::AssertTrap { .. } => continue,
+                wast::WastDirective::AssertReturn { .. } => continue,
+                wast::WastDirective::AssertExhaustion { .. } => continue,
+                wast::WastDirective::AssertException { .. } => continue,
+                // Do not attempt to process invalid modules.
+                wast::WastDirective::AssertMalformed { .. } => continue,
+                wast::WastDirective::AssertInvalid { .. } => continue,
+                wast::WastDirective::AssertUnlinkable { .. } => continue,
+                wast::WastDirective::AssertSuspension { .. } => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+                wast::WastDirective::Thread(_) => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+                wast::WastDirective::Wait { .. } => {
+                    unreachable!("doesn’t actually occur in our test suite");
+                }
+            };
+        }
+    }
 }


### PR DESCRIPTION
Add support for component model to `max_stack` analysis by resetting state every time `End` of a module or component is reached. As a precaution, this is only done for Wasm binaries, which *are not* modules, such that existing behavior does not change, i.e. all the same code paths are taken for Wasm modules.

Components may contain multiple components or modules. Only modules contain anything this analysis cares about though, so simply reset state every time an end of either is reached.