### PR TITLE
fix splat macro ambiguity with builtin attribute (0.6.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finite-wasm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Simonas Kazlauskas <finite-wasm@kazlauskas.me>"]
 license = "MIT OR Apache-2.0"

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -451,7 +451,7 @@ impl<'a, 'b, CostModel: VisitOperator<'b, Output = Fee> + VisitSimdOperator<'b, 
     gen::vternop!(pure_insn);
     gen::vbitmask!(pure_insn);
     gen::vinarrowop!(pure_insn);
-    gen::splat!(pure_insn);
+    gen::splatop!(pure_insn);
     gen::r#const!(pure_insn);
     gen::extractlane!(pure_insn);
     gen::replacelane!(pure_insn);

--- a/src/instruction_categories.rs
+++ b/src/instruction_categories.rs
@@ -391,7 +391,7 @@ macro_rules! vbitmask {
     };
 }
 
-macro_rules! splat {
+macro_rules! splatop {
     ($generator:ident) => {
         $generator! {
             V128.splat = visit_i8x16_splat | visit_i16x8_splat | visit_i32x4_splat
@@ -447,6 +447,6 @@ macro_rules! atomic_cmpxchg {
 
 pub(crate) use {
     atomic_cmpxchg, atomic_rmw, binop, binop_complete, binop_partial, cvtop, cvtop_complete,
-    cvtop_partial, extractlane, load, loadlane, r#const, relop, replacelane, splat, store,
+    cvtop_partial, extractlane, load, loadlane, r#const, relop, replacelane, splatop, store,
     storelane, testop, unop, vbitmask, vinarrowop, vishiftop, vrelop, vternop,
 };

--- a/src/max_stack/instruction_visit.rs
+++ b/src/max_stack/instruction_visit.rs
@@ -160,7 +160,7 @@ impl<'a, Cfg: SizeConfig + ?Sized> Visitor<'a, Cfg> {
     gen::vrelop!(instruction_category);
     gen::vinarrowop!(instruction_category);
     gen::vbitmask!(instruction_category);
-    gen::splat!(instruction_category);
+    gen::splatop!(instruction_category);
     gen::atomic_rmw!(instruction_category);
     gen::atomic_cmpxchg!(instruction_category);
 


### PR DESCRIPTION
Rust nightly `1.98.0 (485ec3fbc 2026-06-10)` introduced a builtin `splat` attribute. The crate-internal `macro_rules! splat` in `src/instruction_categories.rs` then becomes ambiguous with the builtin at its `pub(crate) use` re-export, breaking the build under that nightly:

```
error[E0659]: `splat` is ambiguous
  = note: ambiguous because of a name conflict with a builtin attribute
```

Rename the macro to `splatop` (matching the existing `binop`/`unop`/`relop`/`vternop` naming) and update its re-export and two `gen::splat!` call sites. The `V128.splat` category token, the `. splat =` matchers, and `visit_splat` are unchanged, so emitted behavior is identical. The macro is `pub(crate)`, so this is not a public-API change.

Verified: builds clean on nightly `1.98.0 (2026-06-10)` (which fails before this change); lib tests pass.

This is the 0.6.x line (wasmparser 0.228). The same fix is needed on 0.5.x (wasmparser 0.105) via a separate backport PR, since nearcore consumes both versions.