### PR TITLE
fix splat macro ambiguity with builtin attribute (0.5.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finite-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Simonas Kazlauskas <finite-wasm@kazlauskas.me>"]
 license = "MIT OR Apache-2.0"

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -436,7 +436,7 @@ impl<'a, 'b, CostModel: VisitOperator<'b, Output = u64>> VisitOperator<'b>
     gen::vternop!(pure_insn);
     gen::vbitmask!(pure_insn);
     gen::vinarrowop!(pure_insn);
-    gen::splat!(pure_insn);
+    gen::splatop!(pure_insn);
     gen::r#const!(pure_insn);
     gen::extractlane!(pure_insn);
     gen::replacelane!(pure_insn);

--- a/src/instruction_categories.rs
+++ b/src/instruction_categories.rs
@@ -391,7 +391,7 @@ macro_rules! vbitmask {
     };
 }
 
-macro_rules! splat {
+macro_rules! splatop {
     ($generator:ident) => {
         $generator! {
             V128.splat = visit_i8x16_splat | visit_i16x8_splat | visit_i32x4_splat
@@ -447,6 +447,6 @@ macro_rules! atomic_cmpxchg {
 
 pub(crate) use {
     atomic_cmpxchg, atomic_rmw, binop, binop_complete, binop_partial, cvtop, cvtop_complete,
-    cvtop_partial, extractlane, load, loadlane, r#const, relop, replacelane, splat, store,
+    cvtop_partial, extractlane, load, loadlane, r#const, relop, replacelane, splatop, store,
     storelane, testop, unop, vbitmask, vinarrowop, vishiftop, vrelop, vternop,
 };

--- a/src/max_stack/instruction_visit.rs
+++ b/src/max_stack/instruction_visit.rs
@@ -161,7 +161,7 @@ impl<'a, 's, 'cfg, Cfg: SizeConfig + ?Sized> VisitOperator<'a> for Visitor<'s, C
     gen::vrelop!(instruction_category);
     gen::vinarrowop!(instruction_category);
     gen::vbitmask!(instruction_category);
-    gen::splat!(instruction_category);
+    gen::splatop!(instruction_category);
     gen::atomic_rmw!(instruction_category);
     gen::atomic_cmpxchg!(instruction_category);
 


### PR DESCRIPTION
Backport of #82 to the 0.5.x line (wasmparser 0.105).

Rust nightly `1.98.0 (485ec3fbc 2026-06-10)` introduced a builtin `splat` attribute, making the crate-internal `macro_rules! splat` in `src/instruction_categories.rs` ambiguous with the builtin at its `pub(crate) use` re-export:

```
error[E0659]: `splat` is ambiguous
  = note: ambiguous because of a name conflict with a builtin attribute
```

Rename the macro to `splatop` and update its re-export and the two `gen::splat!` call sites. The `V128.splat` category token, `. splat =` matchers, and `visit_splat` are unchanged, so emitted behavior is identical. The macro is `pub(crate)`, so this is not a public-API change.

nearcore depends on both finite-wasm 0.5.x and 0.6.x simultaneously (different wasmparser majors), so both lines need the patch; #82 covers 0.6.1.

Base branch `release-0.5` was cut from the `0.5.0` tag (following the existing `release-0.4` convention). Verified: builds clean on nightly `1.98.0 (2026-06-10)`.